### PR TITLE
ci: use reusable tests-python-poetry workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,86 +4,13 @@ on:
   pull_request:
     branches:
       - main
-
-  # For manual triggers
   workflow_dispatch:
 
 jobs:
   test:
-    if: github.actor != 'actions[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Setup tests
-        run: |
-          pip install --upgrade pip
-          pip install poetry
-          poetry config virtualenvs.create false
-          poetry install
-
-      - name: Run tests & CodeCov
-        run: |
-          coverage run -m pytest
-          coverage report
-          coverage xml
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-
-  # pre_build:
-  #   if: github.actor != 'actions[bot]'
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: ${{ github.head_ref }}
-
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: '3.9'
-
-  #     - name: Poetry Setup
-  #       run: |
-  #         pip install --upgrade pip
-  #         curl -sSL https://install.python-poetry.org | python3 -
-  #         poetry config virtualenvs.create false
-  #         poetry install
-
-#      - name: Generate and push Tag
-#        run: |
-#          git config --global user.name 'GitHub Actions'
-#          git config --global user.email 'actions@github.com'
-#          git push
-#          git tag -f $(poetry version -s)
-#          git push -f origin --tags
-
-
-      # - name: Build package
-      #   run: poetry build
-
-      # - name: Repository Setup
-      #   run: |
-      #     poetry config repositories.test-pypi https://test.pypi.org/legacy/
-
-      # - name: Publish package to TestPyPI
-      #   env:
-      #     POETRY_PYPI_TOKEN_PYPI: ${{ secrets.TEST_PYPI_TOKEN }}
-      #   run: poetry publish -r test-pypi -u __token__ --password $POETRY_PYPI_TOKEN_PYPI
-
-    environment:
-      name: Development
-      # url: https://test.pypi.org/project/currency-quote/
+    uses: ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1
+    with:
+      python-versions: '["3.9"]'
+      environment: Development
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the previous CI YAML with a thin caller of `ivanildobarauna/github-workflows/.github/workflows/tests-python-poetry.yml@v1`.
- Behavior preserved: Python 3.9, Codecov upload, runs on PRs to `main`, `Development` environment.

## Test plan
- [ ] CI run on this PR is green
- [ ] Codecov upload appears in the run logs